### PR TITLE
add local prefix to avoid warnings

### DIFF
--- a/lib/CrowdSec.lua
+++ b/lib/CrowdSec.lua
@@ -59,7 +59,7 @@ function csmod.allowIp(ip)
   local link = runtime.conf["API_URL"] .. "/v1/decisions?ip=" .. ip
   local resp = {}
   if link:find("https://") == 1 then
-      one, code, headers, status = https.request{
+      local one, code, headers, status = https.request{
                                             url = link,
                                             headers = { 
                                               ['Connection'] = 'close',
@@ -73,7 +73,7 @@ function csmod.allowIp(ip)
                                             verify = "none",
                                             }
   else
-      body, code, headers = http.request{
+      local body, code, headers = http.request{
                                     url = link,
                                     headers = { 
                                       ['Connection'] = 'close',


### PR DESCRIPTION
Avoid warnings like this : 

```
2020/12/28 20:37:35 [warn] 3368#3368: *1 [lua] _G write guard:12: __newindex(): writing a global Lua variable ('headers') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables#012stack traceback:#012#011/usr/local/lib/lua/crowdsec/CrowdSec.lua:85: in function 'allowIp'#012#011access_by_lua(main-lua.conf:166):105: in main chunk, client: 1.3.3.7, server: some.server.com, request: "GET /randomfile1 HTTP/2.0", host: "some.server.com"
```