### PR TITLE
Add REQUEST_TIMEOUT parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,5 @@ API_KEY=                                      <-- the API Key generated with `cs
 LOG_FILE=/tmp/lua_mod.log                     <-- path to log file
 CACHE_EXPIRATION=1                            <-- in seconds
 CACHE_SIZE=1000                               <-- cache size
+REQUEST_TIMEOUT=0.2                           <-- Maximum duration in seconds for a request to LAPI
 ```

--- a/lib/CrowdSec.lua
+++ b/lib/CrowdSec.lua
@@ -4,6 +4,7 @@ local config = require "config"
 local lrucache = require "lrucache"
 local logging = require "logging"
 local log_file = require "logging.file"
+local socket = require "socket"
 local http = require("socket.http")
 local https = require("ssl.https")
 
@@ -71,6 +72,11 @@ function csmod.allowIp(ip)
                                             protocol = "tlsv1",
                                             options = "all",
                                             verify = "none",
+                                            create = function()
+                                              local req_sock = socket.tcp()
+                                              req_sock:settimeout(runtime.conf['REQUEST_TIMEOUT'], 't')
+                                              return req_sock
+                                            end
                                             }
   else
       body, code, headers = http.request{
@@ -81,7 +87,12 @@ function csmod.allowIp(ip)
                                       ['User-Agent'] = runtime.userAgent
                                     },    
                                     content_type = 'application/json',    
-                                    sink = ltn12.sink.table(resp)
+                                    sink = ltn12.sink.table(resp),
+                                    create = function()
+                                      local req_sock = socket.tcp()
+                                      req_sock:settimeout(runtime.conf['REQUEST_TIMEOUT'], 't')
+                                      return req_sock
+                                    end
                                     }
   end
   

--- a/lib/config.lua
+++ b/lib/config.lua
@@ -32,11 +32,14 @@ end
 
 function config.loadConfig(file)
     if not config.file_exists(file) then
-        return nil, "File".. file .." doesn't exist"
+        return nil, "File ".. file .." doesn't exist"
     end
     local conf = {}
     local valid_params = {'API_URL', 'API_KEY', 'LOG_FILE'}
-    local valid_int_params = {'CACHE_EXPIRATION', 'CACHE_SIZE'}
+    local valid_int_params = {'CACHE_EXPIRATION', 'CACHE_SIZE', 'REQUEST_TIMEOUT'}
+    local default_values = {
+        ['REQUEST_TIMEOUT'] = 0.2
+    }
     for line in io.lines(file) do
         local isOk = false
         if starts_with(line, "#") then
@@ -55,8 +58,14 @@ function config.loadConfig(file)
                     break
                 else
                     print("unsupported configuration '" .. v .. "'")
+                    break
                 end
             end
+        end
+    end
+    for k, v in pairs(default_values) do
+        if conf[k] == nil then
+            conf[k] = v
         end
     end
     return conf, nil


### PR DESCRIPTION
The default timeout for HTTP request is 60s, which basically guarantees all requests to nginx will fail if LAPI takes too long to respond.

This PR add a `REQUEST_TIMEOUT` parameter to limit how long the bouncer will block the request if LAPI is slow to respond for any reason.

`REQUEST_TIMEOUT` defaults to 0.2s, which should be more than enough for LAPI to respond in normal operating conditions and not impact user experience too much if it is slow.