### PR TITLE
fix: moved variable to local-scope

### DIFF
--- a/nginx/access.lua
+++ b/nginx/access.lua
@@ -1,4 +1,4 @@
-ok, err = require "crowdsec".allowIp(ngx.var.remote_addr)
+local ok, err = require "crowdsec".allowIp(ngx.var.remote_addr)
 if err ~= nil then 
     ngx.log(ngx.ERR, "[Crowdsec] bouncer error: " .. err)
 end


### PR DESCRIPTION
moved the variables into a local-scope. lua was warning with:
```
/usr/local/openresty/lualib/plugins/crowdsec/access.lua:2: in main chunk, client: xx.xxx.xxx.xxx, server: www.esyoil.com, request: "GET /_nuxt/ac9dd2b.js HTTP/2.0", host: "www.esyoil.com", referrer: "https://www.esyoil.com/"
2022/01/18 16:35:39 [warn] 3341#3341: *10414917 [lua] _G write guard:12: __newindex(): writing a global Lua variable ('err') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
    /usr/local/openresty/lualib/plugins/crowdsec/access.lua:2: in main chunk, client: xx.xxx.xxx.xxx, server: www.esyoil.com, request: "GET /_nuxt/ac9dd2b.js HTTP/2.0", host: "www.esyoil.com", referrer: "https://www.esyoil.com/"
```
about possible race conditions and the error log grew to 36GB.

This patch fixes this - or at least I don't see any more warnings.
