### PR TITLE
Fix empty ret_code behavior and empty line in config

### DIFF
--- a/lib/plugins/crowdsec/ban.lua
+++ b/lib/plugins/crowdsec/ban.lua
@@ -22,8 +22,8 @@ function M.new(template_path, redirect_location, ret_code)
         end
     end
 
-    if ret_code_ok == false then
-        ngx.log(ngx.ERR, "RET_CODE '" .. ret_code .. "' is not supported")
+    if ret_code_ok == false and ret_code ~= 0 and ret_code ~= "" then
+        ngx.log(ngx.ERR, "RET_CODE '" .. ret_code .. "' is not supported, using default HTTP code " .. M.ret_code)
     end
 
     template_file_ok = false

--- a/lib/plugins/crowdsec/config.lua
+++ b/lib/plugins/crowdsec/config.lua
@@ -30,6 +30,11 @@ local function starts_with(str, start)
     return str:sub(1, #start) == start
 end
 
+local function trim(s)
+    return (string.gsub(s, "^%s*(.-)%s*$", "%1"))
+end
+
+
 function config.loadConfig(file)
     if not config.file_exists(file) then
         return nil, "File ".. file .." doesn't exist"
@@ -53,6 +58,9 @@ function config.loadConfig(file)
     for line in io.lines(file) do
         local isOk = false
         if starts_with(line, "#") then
+            isOk = true
+        end
+        if trim(line) == "" then
             isOk = true
         end
         if not isOk then


### PR DESCRIPTION
- Empty ret_code in configuration led to `RET_CODE '' is not supported`, this is now fixed.
- Empty lines in the configuration file led to `unsupported configuration ''`, this is now fixed.