### PR TITLE
exit with ngx.DECLINED when the request is allowed

### DIFF
--- a/lib/crowdsec.lua
+++ b/lib/crowdsec.lua
@@ -569,11 +569,11 @@ end
 
 function csmod.Allow(ip)
   if runtime.conf["ENABLED"] == "false" then
-    return "Disabled", nil
+    ngx.exit(ngx.DECLINED)
   end
 
   if ngx.req.is_internal() then
-    return
+    ngx.exit(ngx.DECLINED)
   end
 
   local remediationSource = flag.BOUNCER_SOURCE
@@ -583,7 +583,7 @@ function csmod.Allow(ip)
     for k, v in pairs(runtime.conf["EXCLUDE_LOCATION"]) do
       if ngx.var.uri == v then
         ngx.log(ngx.ERR,  "whitelisted location: " .. v)
-        return
+        ngx.exit(ngx.DECLINED)
       end
       local uri_to_check = v
       if utils.ends_with(uri_to_check, "/") == false then
@@ -667,8 +667,7 @@ function csmod.Allow(ip)
                 end
                 -- captcha is valid, we redirect the IP to its previous URI but in GET method
                 ngx.req.set_method(ngx.HTTP_GET)
-                ngx.redirect(previous_uri)
-                return
+                return ngx.redirect(previous_uri)
             else
                 ngx.log(ngx.ALERT, "Invalid captcha from " .. ip)
             end
@@ -708,9 +707,11 @@ function csmod.Allow(ip)
                 ngx.log(ngx.ERR, "Lua shared dict (crowdsec cache) is full, please increase dict size in config")
               end
               ngx.log(ngx.ALERT, "[Crowdsec] denied '" .. ip .. "' with '"..remediation.."'")
+              return
           end
       end
   end
+  ngx.exit(ngx.DECLINED)
 end
 
 


### PR DESCRIPTION
Closes https://github.com/crowdsecurity/lua-cs-bouncer/issues/61.

The bouncer is running in the access phase of nginx, and an access handler can have 3 different return code:
 - `ngx.OK`: request is allowed to go through (and bypass any remaining handler in the phase)
 -  `>= ngx.HTTP_OK`: return this code to nginx and skip all remaining phases
 - `ngx.DECLINED`: tell nginx we are not interested in handling the request (and so, we are not taken into account when resolving `satisfy`).
 
`ngx.DECLINED` is not really documented in the LUA module (best I could find is [this](https://forum.openresty.us/d/4257-dc5f7368d6c0b220039fbbc71ed87bce) and [this](https://github.com/openresty/lua-nginx-module/blob/master/t/024-access/satisfy.t#L101)

We didn't explicitly tell nginx we were not interested in handling the request in the following case:
 - The bouncer is disabled in the configuration
 - The bouncer has no decision for the IP
 
 This caused any configuration using `satisfy any` to not behave as expected: because we were implicitly allowing the request, any other check (such as IP or credentials) was ignored.
 
 We now explicitly exit the handler with `ngx.DECLINED` when:
  - The bouncer is not enabled
  - We are in an excluded location
  - We have no decision for the IP
  
  This slightly changes the behavior of the bouncer: if an IP is allowed (through an `allow` directive or correct HTTP credentials) AND nginx is configured with `satisfy any`, the request will be allowed to go through even if there's a decision for the IP or if the appsec component decided to block the request (this can be worked around by using `satisfy all`, but this is not suitable for all situations).
  