### PR TITLE
New config param to allow ban checking on internal requests.

### DIFF
--- a/config_example.conf
+++ b/config_example.conf
@@ -7,6 +7,9 @@ BOUNCING_ON_TYPE=all
 FALLBACK_REMEDIATION=ban
 REQUEST_TIMEOUT=3000
 UPDATE_FREQUENCY=10
+# By default internal requests are ignored, such as any path affected by rewrite rule.
+# set ENABLE_INTERNAL=true to allow checking on these internal requests.
+ENABLE_INTERNAL=false
 # live or stream
 MODE=live
 # exclude the bouncing on those location

--- a/lib/crowdsec.lua
+++ b/lib/crowdsec.lua
@@ -608,7 +608,7 @@ function csmod.Allow(ip)
     ngx.exit(ngx.DECLINED)
   end
 
-  if ngx.req.is_internal() then
+  if runtime.conf["ENABLE_INTERNAL"] == "false" and ngx.req.is_internal() then
     ngx.exit(ngx.DECLINED)
   end
 

--- a/lib/plugins/crowdsec/config.lua
+++ b/lib/plugins/crowdsec/config.lua
@@ -39,12 +39,13 @@ function config.loadConfig(file)
         return nil, "File ".. file .." doesn't exist"
     end
     local conf = {}
-    local valid_params = {'ENABLED','API_URL', 'API_KEY', 'BOUNCING_ON_TYPE', 'MODE', 'SECRET_KEY', 'SITE_KEY', 'BAN_TEMPLATE_PATH' ,'CAPTCHA_TEMPLATE_PATH', 'REDIRECT_LOCATION', 'RET_CODE', 'EXCLUDE_LOCATION', 'FALLBACK_REMEDIATION', 'CAPTCHA_PROVIDER', 'APPSEC_URL', 'APPSEC_FAILURE_ACTION', 'ALWAYS_SEND_TO_APPSEC', 'SSL_VERIFY'}
+    local valid_params = {'ENABLED', 'ENABLE_INTERNAL', 'API_URL', 'API_KEY', 'BOUNCING_ON_TYPE', 'MODE', 'SECRET_KEY', 'SITE_KEY', 'BAN_TEMPLATE_PATH' ,'CAPTCHA_TEMPLATE_PATH', 'REDIRECT_LOCATION', 'RET_CODE', 'EXCLUDE_LOCATION', 'FALLBACK_REMEDIATION', 'CAPTCHA_PROVIDER', 'APPSEC_URL', 'APPSEC_FAILURE_ACTION', 'ALWAYS_SEND_TO_APPSEC', 'SSL_VERIFY'}
     local valid_int_params = {'CACHE_EXPIRATION', 'CACHE_SIZE', 'REQUEST_TIMEOUT', 'UPDATE_FREQUENCY', 'CAPTCHA_EXPIRATION', 'APPSEC_CONNECT_TIMEOUT', 'APPSEC_SEND_TIMEOUT', 'APPSEC_PROCESS_TIMEOUT', 'STREAM_REQUEST_TIMEOUT'}
     local valid_bouncing_on_type_values = {'ban', 'captcha', 'all'}
     local valid_truefalse_values = {'false', 'true'}
     local default_values = {
         ['ENABLED'] = "true",
+        ['ENABLE_INTERNAL'] = "false",
         ['API_URL'] = "",
         ['REQUEST_TIMEOUT'] = 500,
         ['STREAM_REQUEST_TIMEOUT'] = 15000,
@@ -87,6 +88,11 @@ function config.loadConfig(file)
                     ngx.log(ngx.ERR, "unsupported value '" .. value .. "' for variable '" .. key .. "'. Using default value 'true' instead")
                     value = "true"
                 end
+              elseif key == "ENABLE_INTERNAL" then
+                if not has_value(valid_truefalse_values, value) then
+                    ngx.log(ngx.ERR, "unsupported value '" .. value .. "' for variable '" .. key .. "'. Using default value 'false' instead")
+                    value = "false"
+                end
             elseif key == "BOUNCING_ON_TYPE" then
                 if not has_value(valid_bouncing_on_type_values, value) then
                     ngx.log(ngx.ERR, "unsupported value '" .. value .. "' for variable '" .. key .. "'. Using default value 'ban' instead")
@@ -116,7 +122,7 @@ function config.loadConfig(file)
                 value = "ban"
                 end
             end
-            
+
             conf[key] = value
 
         elseif has_value(valid_int_params, key) then


### PR DESCRIPTION

This PR introduces a new parameter `ENABLE_INTERNAL` that allows the bouncer to continue checking of requests that are flagged as `internal` by nginx/openresty.

---

Whilst debugging why many of our sites and paths were creating decisions but the bouncer was not rejecting requests, I discovered that it was our use of rewrite rules prevented the bouncer from rejecting the requests.

Initially I ran for a several weeks with L611-613 in `crowdsec.lua` commented out, this allowed the bouncer to block and we witnessed no other issues or unusual behaviour. 

I'm not sure what other implications of `ngx.req.is_internal()` are, so I've created this PR that doesn't affect the default behavior, but allows disabling the check if you so desire.