### PR TITLE
fix: remove redundant timer creation in SetupStream function

### DIFF
--- a/lib/crowdsec.lua
+++ b/lib/crowdsec.lua
@@ -260,7 +260,7 @@ local function SetupStream()
     end
     local last_refresh = stream.cache:get("last_refresh")
     if last_refresh ~= nil then
-      if now - last_refresh < runtime.conf["UPDATE_FREQUENCY"] then
+      if ngx.time() - last_refresh < runtime.conf["UPDATE_FREQUENCY"] then
         ngx.log(ngx.DEBUG, "last refresh was less than " .. runtime.conf["UPDATE_FREQUENCY"] .. " seconds ago, returning")
         local ok, err = ngx.timer.at(runtime.conf["UPDATE_FREQUENCY"], SetupStreamTimer)
         if not ok then

--- a/lib/crowdsec.lua
+++ b/lib/crowdsec.lua
@@ -286,10 +286,6 @@ local function SetupStream()
 
   if refreshing == true and not ngx.worker.exiting() then
     ngx.log(ngx.DEBUG, "another worker is refreshing the data, returning")
-    local ok, err = ngx.timer.at(runtime.conf["UPDATE_FREQUENCY"], SetupStreamTimer)
-    if not ok then
-      error("Failed to create the timer: " .. (err or "unknown"))
-    end
     return
   end
 
@@ -298,13 +294,8 @@ local function SetupStream()
   if last_refresh ~= nil then
       -- local last_refresh_time = tonumber(last_refresh)
       local now = ngx.time()
-      if now - last_refresh < runtime.conf["UPDATE_FREQUENCY"] and not ngx.worker.exiting() then
-        ngx.log(ngx.DEBUG, "last refresh was less than " .. runtime.conf["UPDATE_FREQUENCY"] .. " seconds ago, returning")
-        local ok, err = ngx.timer.at(runtime.conf["UPDATE_FREQUENCY"], SetupStreamTimer)
-        if not ok then
-          error("Failed to create the timer: " .. (err or "unknown"))
-        end
-        return
+      if now - last_refresh > runtime.conf["UPDATE_FREQUENCY"] *1.1 and not ngx.worker.exiting() then
+        ngx.log(ngx.ERROR, "last refresh was more than " .. runtime.conf["UPDATE_FREQUENCY"] .. " seconds ago, something fishy is going on")
       end
   end
 

--- a/lib/plugins/crowdsec/stream.lua
+++ b/lib/plugins/crowdsec/stream.lua
@@ -173,6 +173,7 @@ function stream:stream_query(api_url, timeout, api_key_header, api_key, user_age
   if status~=200 then
     set_refreshing(false)
     ngx.log(ngx.ERR, "HTTP error while request to Local API '" .. status .. "' with message (" .. tostring(body) .. ")")
+    return "HTTP error while request to Local API '" .. status .. "' with message (" .. tostring(body) .. ")"
   end
 
   local decisions = cjson.decode(body)


### PR DESCRIPTION
Simplified the SetupStream function by removing redundant timer creation logic. This prevents unnecessary timer creation when another worker is already refreshing the data.