### PR TITLE
fix: captcha in live mode

### DIFF
--- a/lib/crowdsec.lua
+++ b/lib/crowdsec.lua
@@ -486,8 +486,8 @@ function csmod.allowIp(ip)
 
     if remediation ~= nil and remediation == "ban" then
       metrics:increment("dropped", 1, {ip_type=ip_version, origin=origin} )
-    return ok, remediation, err
     end
+    return ok, remediation, err
   end
   return true, nil, nil
 end


### PR DESCRIPTION
fix: #123 
fix: #112

I took the presumption that the indentation of the line meant it was meant to be below the `end` clause.