### PR TITLE
feat(mtls): add the option to use TLS authentication for LAPI calls

### DIFF
--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         cat /etc/os-release
         apt-get update
-        apt-get install -y make gcc nginx libnginx-mod-http-lua perl ca-certificates luarocks libnss3-tools
+        apt-get install -y make gcc nginx libnginx-mod-http-lua perl ca-certificates luarocks
         luarocks install lua-cjson 2.1.0.10-1
         luarocks install lua-resty-http  0.17.1-0
         cpan Test::Nginx

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         wget -O mkcert-latest-linux-amd64 "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
         chmod +x mkcert-latest-linux-amd64
-        sudo cp mkcert-latest-linux-amd64 /usr/local/bin/mkcert
+        cp mkcert-latest-linux-amd64 /usr/local/bin/mkcert
 
     - name: "generate local CA"
       run: |

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -28,12 +28,26 @@ jobs:
       run: |
         cat /etc/os-release
         apt-get update
-        apt-get install -y make gcc nginx libnginx-mod-http-lua perl ca-certificates luarocks
+        apt-get install -y make gcc nginx libnginx-mod-http-lua perl ca-certificates luarocks libnss3-tools
         luarocks install lua-cjson 2.1.0.10-1
         luarocks install lua-resty-http  0.17.1-0
         cpan Test::Nginx
         cpan Test::Nginx::Socket
         echo "Installation done"
+
+    - name: "install mkcert"
+      run: |
+        curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
+        chmod +x mkcert-v*-linux-amd64
+        sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+
+    - name: "generate local CA"
+      run: |
+        mkdir -p /tmp/ca-test
+        export CAROOT=/tmp/ca-test
+        mkcert -install
+        mkcert -key-file /tmp/ca-test/server-key.pem -cert-file /tmp/ca-test/server-cert.pem localhost 127.0.0.1
+        mkcert -client -key-file /tmp/ca-test/client-key.pem -cert-file /tmp/ca-test/client-cert.pem bouncer
 
     - name: "Run tests"
       run: |

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -37,9 +37,9 @@ jobs:
 
     - name: "install mkcert"
       run: |
-        curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
-        chmod +x mkcert-v*-linux-amd64
-        sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+        wget -O mkcert-latest-linux-amd64 "https://dl.filippo.io/mkcert/latest?for=linux/amd64"
+        chmod +x mkcert-latest-linux-amd64
+        sudo cp mkcert-latest-linux-amd64 /usr/local/bin/mkcert
 
     - name: "generate local CA"
       run: |

--- a/lib/crowdsec.lua
+++ b/lib/crowdsec.lua
@@ -155,22 +155,20 @@ function csmod.init(configFile, userAgent)
 
     -- Parse client certificate
     if runtime.conf["TLS_CLIENT_CERT"] ~= "" then
-      local cert_file = io.open(runtime.conf["TLS_CLIENT_CERT"], "r")
-      if cert_file then
-        local cert_data = cert_file:read("*all")
-        cert_file:close()
-
-        local cert, err = ssl.parse_pem_cert(cert_data)
-        if not cert then
-          ngx.log(ngx.ERR, "Failed to parse client certificate: " .. (err or "unknown error"))
-          return nil, "Failed to parse client certificate: " .. (err or "unknown error")
-        end
-        runtime.conf["TLS_CLIENT_CERT_PARSED"] = cert
-        ngx.log(ngx.INFO, "Successfully parsed TLS client certificate")
-      else
-        ngx.log(ngx.ERR, "Failed to read client certificate file: " .. runtime.conf["TLS_CLIENT_CERT"])
-        return nil, "Failed to read client certificate file: " .. runtime.conf["TLS_CLIENT_CERT"]
+      local cert_file, err = io.open(runtime.conf["TLS_CLIENT_CERT"], "r")
+      if not cert_file then
+        ngx.log(ngx.ERR, "Failed to open client certificate file: " .. (err or "unknown error"))
+        return nil, "Failed to open client certificate file: " .. (err or "unknown error")
       end
+      local cert_data = cert_file:read("*all")
+      cert_file:close()
+      local cert, err = ssl.parse_pem_cert(cert_data)
+      if not cert then
+        ngx.log(ngx.ERR, "Failed to parse client certificate: " .. (err or "unknown error"))
+        return nil, "Failed to parse client certificate: " .. (err or "unknown error")
+      end
+      runtime.conf["TLS_CLIENT_CERT_PARSED"] = cert
+      ngx.log(ngx.INFO, "Successfully parsed TLS client certificate")
     else
       ngx.log(ngx.ERR, "TLS_CLIENT_CERT path is required when USE_TLS_AUTH is enabled")
       return nil, "TLS_CLIENT_CERT path is required when USE_TLS_AUTH is enabled"
@@ -178,22 +176,20 @@ function csmod.init(configFile, userAgent)
 
     -- Parse client private key
     if runtime.conf["TLS_CLIENT_KEY"] ~= "" then
-      local key_file = io.open(runtime.conf["TLS_CLIENT_KEY"], "r")
-      if key_file then
-        local key_data = key_file:read("*all")
-        key_file:close()
-
-        local key, err = ssl.parse_pem_priv_key(key_data)
-        if not key then
-          ngx.log(ngx.ERR, "Failed to parse client private key: " .. (err or "unknown error"))
-          return nil, "Failed to parse client private key: " .. (err or "unknown error")
-        end
-        runtime.conf["TLS_CLIENT_KEY_PARSED"] = key
-        ngx.log(ngx.INFO, "Successfully parsed TLS client private key")
-      else
-        ngx.log(ngx.ERR, "Failed to read client private key file: " .. runtime.conf["TLS_CLIENT_KEY"])
-        return nil, "Failed to read client private key file: " .. runtime.conf["TLS_CLIENT_KEY"]
+      local key_file, err = io.open(runtime.conf["TLS_CLIENT_KEY"], "r")
+      if not key_file then
+        ngx.log(ngx.ERR, "Failed to open client private key: " .. (err or "unknown error"))
+        return nil, "Failed to open client private key: " .. (err or "unknown error")
       end
+      local key_data = key_file:read("*all")
+      key_file:close()
+      local key, err = ssl.parse_pem_priv_key(key_data)
+      if not key then
+        ngx.log(ngx.ERR, "Failed to parse client private key: " .. (err or "unknown error"))
+        return nil, "Failed to parse client private key: " .. (err or "unknown error")
+      end
+      runtime.conf["TLS_CLIENT_KEY_PARSED"] = key
+      ngx.log(ngx.INFO, "Successfully parsed TLS client private key")
     else
       ngx.log(ngx.ERR, "TLS_CLIENT_KEY path is required when USE_TLS_AUTH is enabled")
       return nil, "TLS_CLIENT_KEY path is required when USE_TLS_AUTH is enabled"

--- a/lib/plugins/crowdsec/config.lua
+++ b/lib/plugins/crowdsec/config.lua
@@ -1,6 +1,6 @@
 local config = {}
 
-local valid_params = {'ENABLED', 'ENABLE_INTERNAL', 'API_URL', 'API_KEY', 'BOUNCING_ON_TYPE', 'MODE', 'SECRET_KEY', 'SITE_KEY', 'BAN_TEMPLATE_PATH' ,'CAPTCHA_TEMPLATE_PATH', 'REDIRECT_LOCATION', 'RET_CODE', 'CAPTCHA_RET_CODE', 'EXCLUDE_LOCATION', 'FALLBACK_REMEDIATION', 'CAPTCHA_PROVIDER', 'APPSEC_URL', 'APPSEC_FAILURE_ACTION', 'ALWAYS_SEND_TO_APPSEC', 'SSL_VERIFY'}
+local valid_params = {'ENABLED', 'ENABLE_INTERNAL', 'API_URL', 'API_KEY', 'BOUNCING_ON_TYPE', 'MODE', 'SECRET_KEY', 'SITE_KEY', 'BAN_TEMPLATE_PATH' ,'CAPTCHA_TEMPLATE_PATH', 'REDIRECT_LOCATION', 'RET_CODE', 'CAPTCHA_RET_CODE', 'EXCLUDE_LOCATION', 'FALLBACK_REMEDIATION', 'CAPTCHA_PROVIDER', 'APPSEC_URL', 'APPSEC_FAILURE_ACTION', 'ALWAYS_SEND_TO_APPSEC', 'SSL_VERIFY', 'USE_TLS_AUTH', 'TLS_CLIENT_CERT', 'TLS_CLIENT_KEY'}
 local valid_int_params = {'CACHE_EXPIRATION', 'CACHE_SIZE', 'REQUEST_TIMEOUT', 'UPDATE_FREQUENCY', 'CAPTCHA_EXPIRATION', 'APPSEC_CONNECT_TIMEOUT', 'APPSEC_SEND_TIMEOUT', 'APPSEC_PROCESS_TIMEOUT', 'STREAM_REQUEST_TIMEOUT'}
 -- CACHE_SIZE is not used in the code, but as is was valid parameter for the configuration file, not removing it now
 local valid_bouncing_on_type_values = {'ban', 'captcha', 'all'}
@@ -28,6 +28,9 @@ local default_values = {
     ['ALWAYS_SEND_TO_APPSEC'] = "false",
     ['CAPTCHA_RET_CODE'] = 0,
     ['CACHE_EXPIRATION'] = 1,
+    ['USE_TLS_AUTH'] = "false",
+    ['TLS_CLIENT_CERT'] = "",
+    ['TLS_CLIENT_KEY'] = "",
 }
 
 
@@ -103,6 +106,11 @@ function config.loadConfig(file, default)
                 if not has_value(valid_truefalse_values, value) then
                     ngx.log(ngx.ERR, "unsupported value '" .. value .. "' for variable '" .. key .. "'. Using default value 'true' instead")
                     value = "true"
+                end
+            elseif key == "USE_TLS_AUTH" then
+                if not has_value(valid_truefalse_values, value) then
+                    ngx.log(ngx.ERR, "unsupported value '" .. value .. "' for variable '" .. key .. "'. Using default value 'false' instead")
+                    value = "false"
                 end
             elseif key == "MODE" then
                 if not has_value({'stream', 'live'}, value) then

--- a/lib/plugins/crowdsec/utils.lua
+++ b/lib/plugins/crowdsec/utils.lua
@@ -91,6 +91,24 @@ function M.item_to_string(item, scope)
   return ip_version.."_"..ip_netmask.."_"..ip_network_address, ip_version
 end
 
+
+function M.get_remediation_http_request_tls(link,timeout, user_agent,ssl_verify, ssl_client_cert, ssl_client_priv_key)
+  local httpc = http.new()
+  httpc:set_timeout(timeout)
+  local res, err = httpc:request_uri(link, {
+    method = "GET",
+    headers = {
+      ['Connection'] = 'close',
+      ['User-Agent'] = user_agent
+    },
+    ssl_verify = ssl_verify,
+    ssl_client_cert = ssl_client_cert,
+    ssl_client_priv_key = ssl_client_priv_key
+  })
+  httpc:close()
+  return res, err
+end
+
 function M.get_remediation_http_request(link,timeout, api_key_header, api_key, user_agent,ssl_verify)
   local httpc = http.new()
   httpc:set_timeout(timeout)

--- a/t/17live_and_tls.t
+++ b/t/17live_and_tls.t
@@ -1,0 +1,69 @@
+use Test::Nginx::Socket 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: TLS Auth mode test
+
+--- main_config
+load_module /usr/share/nginx/modules/ndk_http_module.so;
+load_module /usr/share/nginx/modules/ngx_http_lua_module.so;
+
+--- http_config
+
+lua_package_path './lib/?.lua;;';
+lua_shared_dict crowdsec_cache 50m;
+lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+
+init_by_lua_block
+{
+        cs = require "crowdsec"
+        local ok, err = cs.init("./t/conf_t/03_tls_crowdsec_nginx_bouncer.conf", "crowdsec-nginx-bouncer/v1.0.8")
+        if ok == nil then
+                ngx.log(ngx.ERR, "[Crowdsec] " .. err)
+                error()
+        end
+        ngx.log(ngx.ALERT, "[Crowdsec] Initialisation done")
+}
+
+access_by_lua_block {
+        local cs = require "crowdsec"
+        cs.Allow(ngx.var.remote_addr)
+}
+
+server {
+    listen 8081 ssl;
+    ssl_certificate /tmp/ca-test/server-cert.pem;
+    ssl_certificate_key /tmp/ca-test/server-key.pem;
+    ssl_client_certificate /tmp/ca-test/rootCA.pem;
+    ssl_verify_client on;
+
+    location = /v1/decisions {
+        content_by_lua_block {
+            local args, err = ngx.req.get_uri_args()
+            if args.ip == "1.1.1.1" then
+               ngx.say('[{"duration":"1h00m00s","id":4091593,"origin":"CAPI","scenario":"crowdsecurity/vpatch-CVE-2024-4577","scope":"Ip","type":"ban","value":"1.1.1.1"}]')
+            else
+               ngx.say('[{}]')
+            end
+        }
+    }
+}
+
+--- config
+
+location = /t {
+    set_real_ip_from 127.0.0.1;
+    real_ip_header   X-Forwarded-For;
+    real_ip_recursive on;
+    content_by_lua_block {
+        ngx.say(ngx.var.remote_addr)
+    }
+}
+
+--- more_headers
+X-Forwarded-For: 1.1.1.1
+--- request
+GET /t
+--- error_code: 403

--- a/t/17live_and_tls.t
+++ b/t/17live_and_tls.t
@@ -4,7 +4,7 @@ run_tests();
 
 __DATA__
 
-=== TEST 1: TLS Auth mode test
+=== TEST 17: TLS Auth mode test
 
 --- main_config
 load_module /usr/share/nginx/modules/ndk_http_module.so;
@@ -19,7 +19,7 @@ lua_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
 init_by_lua_block
 {
         cs = require "crowdsec"
-        local ok, err = cs.init("./t/conf_t/03_tls_crowdsec_nginx_bouncer.conf", "crowdsec-nginx-bouncer/v1.0.8")
+        local ok, err = cs.init("./t/conf_t/17_live_and_tls_crowdsec_nginx_bouncer.conf", "crowdsec-nginx-bouncer/v1.0.8")
         if ok == nil then
                 ngx.log(ngx.ERR, "[Crowdsec] " .. err)
                 error()

--- a/t/conf_t/17_live_and_tls_crowdsec_nginx_bouncer.conf
+++ b/t/conf_t/17_live_and_tls_crowdsec_nginx_bouncer.conf
@@ -3,8 +3,8 @@ ENABLED=true
 API_URL=https://127.0.0.1:8081
 API_KEY=
 USE_TLS_AUTH=true
-TLS_CERT_PATH=/tmp/ca-test/client-cert.pem
-TLS_KEY_PATH=/tmp/ca-test/client-key.pem
+TLS_CLIENT_CERT=/tmp/ca-test/client-cert.pem
+TLS_CLIENT_KEY=/tmp/ca-test/client-key.pem
 CACHE_EXPIRATION=1
 # bounce for all type of remediation that the bouncer can receive from the local API
 BOUNCING_ON_TYPE=all

--- a/t/conf_t/17_live_and_tls_crowdsec_nginx_bouncer.conf
+++ b/t/conf_t/17_live_and_tls_crowdsec_nginx_bouncer.conf
@@ -1,26 +1,23 @@
+APPSEC_URL=http://127.0.0.1:7422
 ENABLED=true
-API_URL=${CROWDSEC_LAPI_URL}
-# Authentication options, either using an API key or TLS client certificate.
-API_KEY=${API_KEY}
-USE_TLS_AUTH=false
-TLS_CLIENT_CERT=/path/to/client.crt
-TLS_CLIENT_KEY=/path/to/client.key
+API_URL=https://127.0.0.1:8081
+API_KEY=
+USE_TLS_AUTH=true
+TLS_CERT_PATH=/tmp/ca-test/client-cert.pem
+TLS_KEY_PATH=/tmp/ca-test/client-key.pem
 CACHE_EXPIRATION=1
 # bounce for all type of remediation that the bouncer can receive from the local API
 BOUNCING_ON_TYPE=all
 FALLBACK_REMEDIATION=ban
 REQUEST_TIMEOUT=3000
 UPDATE_FREQUENCY=10
-# By default internal requests are ignored, such as any path affected by rewrite rule.
-# set ENABLE_INTERNAL=true to allow checking on these internal requests.
-ENABLE_INTERNAL=false
 # live or stream
 MODE=live
 # exclude the bouncing on those location
-EXCLUDE_LOCATION=
+EXCLUDE_LOCATION=/v1/decisions
 #those apply for "ban" action
 # /!\ REDIRECT_LOCATION and RET_CODE can't be used together. REDIRECT_LOCATION take priority over RET_CODE
-BAN_TEMPLATE_PATH=/var/lib/crowdsec/lua/templates/ban.html
+BAN_TEMPLATE_PATH=./ban
 REDIRECT_LOCATION=
 RET_CODE=
 #those apply for "captcha" action
@@ -32,11 +29,4 @@ SECRET_KEY=
 SITE_KEY=
 CAPTCHA_TEMPLATE_PATH=/var/lib/crowdsec/lua/templates/captcha.html
 CAPTCHA_EXPIRATION=3600
-
-APPSEC_URL=
-APPSEC_FAILURE_ACTION=passthrough
-APPSEC_CONNECT_TIMEOUT=
-APPSEC_SEND_TIMEOUT=
-APPSEC_PROCESS_TIMEOUT=
-ALWAYS_SEND_TO_APPSEC=false
-SSL_VERIFY=true
+#METRICS_PERIOD=60


### PR DESCRIPTION
Hello,

Here is an implementation for mTLS usage when fetching for remediation.
It leverages on the already included [lua-resty-http](https://github.com/ledgetech/lua-resty-http) module features.

If the `USE_TLS_AUTH` config variables is set to `true`, then the module try to load the certificate and its key.
Depending of this varaibles, the crowdsec module either call the `_api` or the `_tls` version `live_query` / `stream_query`.

I tried to build a test that works with the current format, but I'm not really familiar neither with testing TLS thing in CI, neither with Perl, so I leverage mkcert tool and I copy-pasty-customized the `02live.t` setup, but with ssl option on the mock of the crowdsec API.