### PR TITLE
Fix nil handling in utils.item_to_string calls

### DIFF
--- a/lib/plugins/crowdsec/live.lua
+++ b/lib/plugins/crowdsec/live.lua
@@ -89,6 +89,10 @@ function live:live_query_process(res, ip, cache_expiration, bouncing_on_type, li
   if body == "null" then -- no result from API, no decision for this IP
     -- set ip in cache and DON'T block it
     local key,_ = utils.item_to_string(ip, "ip")
+    if key == nil then
+      ngx.log(ngx.WARN, "[Crowdsec] Failed to parse IP address for caching: " .. tostring(ip) .. " - skipping cache")
+      return true, nil, nil, nil
+    end
     local succ, err, forcible = live.cache:set("decision_cache/" .. key, "none", cache_expiration, 1)
     --
     ngx.log(ngx.DEBUG, "[CACHE] Adding '" .. key .. "' in cache for '" .. cache_expiration .. "' seconds") --debug
@@ -107,6 +111,10 @@ function live:live_query_process(res, ip, cache_expiration, bouncing_on_type, li
   end
   local cache_value = decision.type .. "/" .. decision.origin
   local key,_ = utils.item_to_string(decision.value, decision.scope)
+  if key == nil then
+    ngx.log(ngx.WARN, "[Crowdsec] Failed to parse decision value for caching: " .. tostring(decision.value) .. " with scope: " .. tostring(decision.scope) .. " - skipping cache")
+    return true, nil, nil, nil
+  end
   local succ, err, forcible = live.cache:set("decision_cache/" .. key, cache_value, cache_expiration, 0)
   ngx.log(ngx.DEBUG, "[CACHE] Adding '" .. key .. "' in cache for '" .. cache_expiration .. "' seconds with decision type'" .. decision.type .. "'with origin'" .. decision.origin ) --debug
   if not succ then

--- a/lib/plugins/crowdsec/stream.lua
+++ b/lib/plugins/crowdsec/stream.lua
@@ -233,17 +233,18 @@ function stream:stream_query_process(res, bouncing_on_type)
         decision.origin = "lists:" .. decision.scenario
       end
 
+      local delete_key, _ = utils.item_to_string(decision.value, decision.scope)
+      if delete_key ~= nil then
+        self:delete(delete_key)
+      else
+        ngx.log(ngx.WARN, "[Crowdsec] Failed to parse decision value for deletion: " .. tostring(decision.value) .. " with scope: " .. tostring(decision.scope))
+      end
+      -- cache space for captcha is different it's used to cache if the captcha has been solved
+      if decision.type == "captcha" then
+        stream.cache:delete("captcha_" .. decision.value)
+      end
       local key, _ = utils.item_to_string(decision.value, decision.scope)
       if key ~= nil then
-        -- Delete from decision cache
-        self:delete(key)
-        
-        -- cache space for captcha is different it's used to cache if the captcha has been solved
-        if decision.type == "captcha" then
-          stream.cache:delete("captcha_" .. decision.value)
-        end
-        
-        -- Check if there's a cached value to delete and count
         local cache_value = stream.cache:get(key)
         if cache_value ~= nil then
           stream.cache:delete(key)
@@ -255,7 +256,7 @@ function stream:stream_query_process(res, bouncing_on_type)
         end
         ngx.log(ngx.DEBUG, "Deleting '" .. key .. "'")
       else
-        ngx.log(ngx.WARN, "[Crowdsec] Failed to parse decision value: " .. tostring(decision.value) .. " with scope: " .. tostring(decision.scope) .. " - skipping deletion")
+        ngx.log(ngx.WARN, "[Crowdsec] Failed to parse decision value for cache lookup: " .. tostring(decision.value) .. " with scope: " .. tostring(decision.scope))
       end
     end
   end

--- a/lib/plugins/crowdsec/stream.lua
+++ b/lib/plugins/crowdsec/stream.lua
@@ -233,9 +233,9 @@ function stream:stream_query_process(res, bouncing_on_type)
         decision.origin = "lists:" .. decision.scenario
       end
 
-      local delete_key, _ = utils.item_to_string(decision.value, decision.scope)
-      if delete_key ~= nil then
-        self:delete(delete_key)
+      local key, _ = utils.item_to_string(decision.value, decision.scope)
+      if key ~= nil then
+        self:delete(key)
       else
         ngx.log(ngx.WARN, "[Crowdsec] Failed to parse decision value for deletion: " .. tostring(decision.value) .. " with scope: " .. tostring(decision.scope))
       end
@@ -243,7 +243,6 @@ function stream:stream_query_process(res, bouncing_on_type)
       if decision.type == "captcha" then
         stream.cache:delete("captcha_" .. decision.value)
       end
-      local key, _ = utils.item_to_string(decision.value, decision.scope)
       if key ~= nil then
         local cache_value = stream.cache:get(key)
         if cache_value ~= nil then

--- a/lib/plugins/crowdsec/utils.lua
+++ b/lib/plugins/crowdsec/utils.lua
@@ -62,9 +62,11 @@ function M.item_to_string(item, scope)
   local ip, cidr, ip_version
   if scope:lower() == "ip" then
     ip = item
-  end
-  if scope:lower() == "range" then
+  elseif scope:lower() == "range" then
     ip, cidr = iputils.splitRange(item, scope)
+  else
+    -- Unsupported scope - this shouldn't happen but you never know
+    return nil, nil
   end
 
   local ip_network_address, is_ipv4 = iputils.parseIPAddress(ip)


### PR DESCRIPTION
fix #128 

- Add nil checks and proper error handling for utils.item_to_string calls
- Prevent runtime errors when item_to_string returns nil values
- Add warning logs when parsing fails to help with debugging
- Skip processing invalid decisions gracefully instead of crashing
- Fix issues in both stream.lua and live.lua files

This resolves the runtime error:
"attempt to concatenate local 'ip_type' (a nil value)"

The code now handles cases where IP addresses or decision values cannot be parsed and logs appropriate warnings while continuing execution.