### PR TITLE
PoC: add provider Cap.js

### DIFF
--- a/config_example.conf
+++ b/config_example.conf
@@ -24,7 +24,7 @@ BAN_TEMPLATE_PATH=/var/lib/crowdsec/lua/templates/ban.html
 REDIRECT_LOCATION=
 RET_CODE=
 #those apply for "captcha" action
-#valid providers are recaptcha, hcaptcha, turnstile
+#valid providers are recaptcha, hcaptcha, turnstile, cap
 CAPTCHA_PROVIDER=
 # Captcha Secret Key
 SECRET_KEY=
@@ -32,6 +32,11 @@ SECRET_KEY=
 SITE_KEY=
 CAPTCHA_TEMPLATE_PATH=/var/lib/crowdsec/lua/templates/captcha.html
 CAPTCHA_EXPIRATION=3600
+
+# Cap provider options (only used when CAPTCHA_PROVIDER=cap)
+# Cap is a self-hosted, privacy-friendly proof-of-work captcha: https://capjs.js.org
+CAPTCHA_VERIFY_URL=
+CAPTCHA_JS_URL=
 
 APPSEC_URL=
 APPSEC_FAILURE_ACTION=passthrough

--- a/lib/crowdsec.lua
+++ b/lib/crowdsec.lua
@@ -114,7 +114,7 @@ function csmod.init(configFile, userAgent)
   end
 
   local captcha_ok = true
-  local err = captcha.New(runtime.conf["SITE_KEY"], runtime.conf["SECRET_KEY"], runtime.conf["CAPTCHA_TEMPLATE_PATH"], runtime.conf["CAPTCHA_PROVIDER"], runtime.conf["CAPTCHA_RET_CODE"])
+  local err = captcha.New(runtime.conf["SITE_KEY"], runtime.conf["SECRET_KEY"], runtime.conf["CAPTCHA_TEMPLATE_PATH"], runtime.conf["CAPTCHA_PROVIDER"], runtime.conf["CAPTCHA_RET_CODE"], runtime.conf["CAPTCHA_VERIFY_URL"], runtime.conf["CAPTCHA_JS_URL"])
   if err ~= nil then
     ngx.log(ngx.ERR, "error loading captcha plugin: " .. err)
     captcha_ok = false

--- a/lib/plugins/crowdsec/captcha.lua
+++ b/lib/plugins/crowdsec/captcha.lua
@@ -9,23 +9,29 @@ local captcha_backend_url = {}
 captcha_backend_url["recaptcha"] = "https://www.recaptcha.net/recaptcha/api/siteverify"
 captcha_backend_url["hcaptcha"] = "https://hcaptcha.com/siteverify"
 captcha_backend_url["turnstile"] = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+-- cap: self-hosted proof-of-work captcha (https://capjs.js.org)
+-- The verify URL is configurable via CAPTCHA_VERIFY_URL (defaults to http://localhost:3000/api/validate)
+captcha_backend_url["cap"] = nil -- set dynamically in New() from CAPTCHA_VERIFY_URL
 
 local captcha_frontend_js = {}
 captcha_frontend_js["recaptcha"] = "https://www.recaptcha.net/recaptcha/api.js"
 captcha_frontend_js["hcaptcha"] = "https://js.hcaptcha.com/1/api.js"
 captcha_frontend_js["turnstile"] = "https://challenges.cloudflare.com/turnstile/v0/api.js"
+-- cap: widget JS URL is configurable via CAPTCHA_JS_URL (defaults to http://localhost:3000/cap.js)
+captcha_frontend_js["cap"] = nil -- set dynamically in New() from CAPTCHA_JS_URL
 
 local captcha_frontend_key = {}
 captcha_frontend_key["recaptcha"] = "g-recaptcha"
 captcha_frontend_key["hcaptcha"] = "h-captcha"
 captcha_frontend_key["turnstile"] = "cf-turnstile"
+captcha_frontend_key["cap"] = "cap"
 
 M.SecretKey = ""
 M.SiteKey = ""
 M.Template = ""
 M.ret_code = ngx.HTTP_OK
 
-function M.New(siteKey, secretKey, TemplateFilePath, captcha_provider, ret_code)
+function M.New(siteKey, secretKey, TemplateFilePath, captcha_provider, ret_code, captcha_verify_url, captcha_js_url)
 
     if siteKey == nil or siteKey == "" then
       return "no recaptcha site key provided, can't use recaptcha"
@@ -66,6 +72,14 @@ function M.New(siteKey, secretKey, TemplateFilePath, captcha_provider, ret_code)
         end
     end
 
+    -- For the cap provider, the backend URL and frontend JS URL are configurable
+    -- because Cap is self-hosted. We read them from the runtime config passed via
+    -- the extra parameters, falling back to the canonical defaults.
+    if captcha_provider == "cap" then
+        captcha_backend_url["cap"] = (captcha_verify_url ~= nil and captcha_verify_url ~= "") and captcha_verify_url or "http://localhost:3000/api/validate"
+        captcha_frontend_js["cap"] = (captcha_js_url     ~= nil and captcha_js_url     ~= "") and captcha_js_url     or "http://localhost:3000/cap.js"
+    end
+
     local template_data = {}
     template_data["captcha_site_key"] =  M.SiteKey
     template_data["captcha_frontend_js"] = captcha_frontend_js[M.CaptchaProvider]
@@ -88,13 +102,19 @@ function M.GetCaptchaBackendKey()
     return captcha_frontend_key[M.CaptchaProvider] .. "-response"
 end
 
-function table_to_encoded_url(args)
+local function table_to_encoded_url(args)
     local params = {}
     for k, v in pairs(args) do table.insert(params, k .. '=' .. v) end
     return table.concat(params, "&")
 end
 
 function M.Validate(captcha_res, remote_ip)
+    -- Cap uses a JSON POST to a self-hosted server instead of form-encoded POST
+    -- to a third-party API, so it needs its own request path.
+    if M.CaptchaProvider == "cap" then
+        return M.ValidateCap(captcha_res, remote_ip)
+    end
+
     local body = {
         secret   = M.SecretKey,
         response = captcha_res,
@@ -127,6 +147,34 @@ function M.Validate(captcha_res, remote_ip)
       end 
     end
 
+    return result.success, nil
+end
+
+-- Cap validation: POST JSON { token, secret } to the self-hosted Cap server.
+-- The Cap server responds with { "success": true } or { "success": false }.
+function M.ValidateCap(captcha_res, remote_ip)
+    local payload = cjson.encode({
+        token    = captcha_res,
+        secret   = M.SecretKey,
+        remoteip = remote_ip,
+    })
+
+    local httpc = http.new()
+    httpc:set_timeout(2000)
+    local res, err = httpc:request_uri(captcha_backend_url["cap"], {
+        method = "POST",
+        body   = payload,
+        headers = {
+            ["Content-Type"] = "application/json",
+        },
+    })
+    httpc:close()
+
+    if err ~= nil then
+        return true, err
+    end
+
+    local result = cjson.decode(res.body)
     return result.success, nil
 end
 


### PR DESCRIPTION
## Summary

Adds **[Cap](https://capjs.js.org)** as a fourth supported captcha provider
(`CAPTCHA_PROVIDER=cap`), alongside the existing `recaptcha`, `hcaptcha` and
`turnstile`.

Cap is a self-hosted, privacy-friendly proof-of-work captcha:
- **No third-party service** — validation is done against your own Cap server
- **No tracking, no fingerprinting, no cookies**
- **GDPR/ePrivacy friendly**
- **Free and open-source** (MIT)

## Files changed

| File | Change |
|------|--------|
| `lib/plugins/crowdsec/captcha.lua` | Add `cap` to the three lookup tables; add `ValidateCap()` (JSON POST instead of form-encoded); dispatch in `Validate()`; accept two new optional params in `New()` |
| `lib/crowdsec.lua` | Pass `CAPTCHA_VERIFY_URL` and `CAPTCHA_JS_URL` to `captcha.New()` — **one line changed** |
| `config_example.conf` | Document the two new optional keys |

`crowdsec.lua` already passes `CAPTCHA_PROVIDER` to `captcha.New()`, so the
provider dispatch required no structural changes there.

## New configuration keys

Only read when `CAPTCHA_PROVIDER=cap`. Existing configurations are unaffected.

```ini
CAPTCHA_PROVIDER=cap
SITE_KEY=<your-cap-site-key>
SECRET_KEY=<your-cap-secret-key>

# URL of your Cap server's validation endpoint
# Default: http://localhost:3000/api/validate
CAPTCHA_VERIFY_URL=http://cap:3000/api/validate

# URL from which browsers load the Cap widget JS
# Default: http://localhost:3000/cap.js
CAPTCHA_JS_URL=http://cap:3000/cap.js
```

## How Cap validation differs from the other providers

The three existing providers (recaptcha, hcaptcha, turnstile) all use the same
protocol: a form-encoded POST to a third-party HTTPS endpoint that returns
`{"success": true/false}`.

Cap uses a **JSON POST** to a self-hosted endpoint. The new `ValidateCap()`
function handles this; the existing `Validate()` path is unchanged.

```
Browser                  Nginx bouncer              Cap server (self-hosted)
  │  POST cap-response=… │                           │
  │──────────────────────>│                           │
  │                       │  POST /api/validate       │
  │                       │  { token, secret }  JSON  │
  │                       │──────────────────────────>│
  │                       │  { "success": true }      │
  │                       │<──────────────────────────│
  │  302 → original URI   │                           │
  │<──────────────────────│                           │
```

## Template

The existing `captcha.html` template is already rendered with
`captcha_frontend_js`, `captcha_frontend_key` and `captcha_site_key`
placeholders. For Cap, those resolve to:

| Placeholder | Value |
|---|---|
| `captcha_frontend_js` | value of `CAPTCHA_JS_URL` |
| `captcha_frontend_key` | `cap` |
| `captcha_site_key` | value of `SITE_KEY` |

A minimal working template snippet for Cap:
```html
<script src="[[captcha_frontend_js]]"></script>
<[[captcha_frontend_key]]-widget data-cap-key="[[captcha_site_key]]"></[[captcha_frontend_key]]-widget>
<input type="hidden" name="[[captcha_frontend_key]]-response" id="cap-response">
<script>
  document.addEventListener('cap:success', function(e) {
    document.getElementById('cap-response').value = e.detail.token;
  });
</script>
```

## Checklist

- [x] No breaking changes — existing providers are untouched
- [x] Default values keep backward compatibility (`crowdsec.lua` passes `nil` for the new params if keys are absent from config)
- [x] `GetCaptchaBackendKey()` returns `cap-response` for the Cap provider, consistent with the form field name
- [x] `config_example.conf` comment updated (`#valid providers are recaptcha, hcaptcha, turnstile, cap`)
