### PR TITLE
fix: guard read_body against HTTP/2 reload crash in captcha verify state

### DIFF
--- a/lib/crowdsec.lua
+++ b/lib/crowdsec.lua
@@ -753,8 +753,18 @@ function csmod.Allow(ip)
     local source, state_id, err = flag.GetFlags(flags)
 
     if previous_uri ~= nil and state_id == flag.VERIFY_STATE then
-      ngx.req.read_body()
-      local args, err = ngx.req.get_post_args()
+      -- HTTP/2 and HTTP/3 requests without Content-Length cause read_body to error.
+      -- Browsers reloading the captcha page send HTTP/2 GET with no Content-Length,
+      -- so we skip body-reading in that case and fall through to re-serve the captcha.
+      -- Genuine captcha form submissions are POSTs with Content-Length set.
+      local can_read_body = not (ngx.req.http_version() >= 2 and ngx.var.http_content_length == nil)
+      local args, err
+      if can_read_body then
+        ngx.req.read_body()
+        args, err = ngx.req.get_post_args()
+      else
+        args = {}
+      end
 
       if args and not err then
         local captcha_res = args[csmod.GetCaptchaBackendKey()] or 0


### PR DESCRIPTION
## Summary

Fixes a runtime crash when a client with a `captcha`-type decision reloads the
challenge page over HTTP/2. Closes #63.

## Problem

`ngx.req.read_body()` raises an error for HTTP/2 (and HTTP/3) requests without
a Content-Length header. The body-read inside `csmod.Allow()`'s captcha
verify-state handler is unguarded, so any HTTP/2 GET reload of the captcha
page crashes nginx with HTTP 500:

```
lua entry thread aborted: runtime error:
.../crowdsec.lua:NNN: http2 requests are not supported without content-length header
stack traceback:
[C]: in function 'read_body'
.../crowdsec.lua:NNN: in function 'Allow'
```

The `get_body()` helper already implements the correct guard; this PR applies
the same pattern to the second `read_body` call site.

## Reproduction

1. Deploy `crowdsec-nginx-bouncer` with a captcha provider configured (e.g. Turnstile, hCaptcha)
2. Serve a site over HTTP/2 (default for HTTPS on modern nginx)
3. Force a captcha decision: `cscli decisions add -i <your-ip> -t captcha -d 10m`
4. Visit the site in a browser → captcha page renders (first request, state cache empty)
5. **Reload the page** → HTTP 500 + `read_body` error in nginx error log

## Fix

Mirror the HTTP/2 protocol-version guard from `get_body()`. When the body is
unreadable, skip the read and fall through with an empty args table, which
correctly re-serves the captcha page. Captcha form submissions are POSTs
with Content-Length, so they're unaffected.

## Compatibility

- HTTP/1.1: behavior unchanged
- HTTP/2 GET (e.g. reload of captcha page): no longer crashes; re-serves captcha
- HTTP/2 POST with Content-Length (captcha form submission): behavior unchanged
- HTTP/2 POST without Content-Length: body skipped (same as `get_body` behavior)

## Tested

- Reproduced the crash on a production deployment of `crowdsec-nginx-bouncer v1.1.6`
- Applied the patch and verified:
- First captcha load renders normally
- Reload of the captcha page no longer crashes
- Captcha form submission validates and unblocks the IP as expected
- Verified no regression in HTTP/1.1 flow
EOF
)"