### PR TITLE
metrics: ensure feature_flags is an empty array, not an object

### DIFF
--- a/lib/plugins/crowdsec/metrics.lua
+++ b/lib/plugins/crowdsec/metrics.lua
@@ -146,7 +146,13 @@ function metrics:toJson(window)
     }
   }
   table.insert(remediation_components, remediation_component)
-  return cjson.encode({log_processors = cjson.null, remediation_components = remediation_components})
+  local encoded = cjson.encode({log_processors = cjson.null, remediation_components = remediation_components})
+  -- feature_flags must serialize as a JSON array []. OpenResty's cjson honors the
+  -- array_mt set above, but vanilla lua-cjson (e.g. Alpine's lua5.1-cjson, used by
+  -- some builds) has no array_mt and emits {} for empty tables, which LAPI rejects
+  -- with HTTP 400 (cannot unmarshal object into []string). Force the literal here so
+  -- the payload is valid regardless of the cjson variant in use.
+  return (encoded:gsub('"feature_flags":{}', '"feature_flags":[]'))
 end
 
 function metrics:sendMetrics(link, headers, ssl, window)

--- a/t/11_live_ban_and_metrics.t
+++ b/t/11_live_ban_and_metrics.t
@@ -114,6 +114,11 @@ server {
                 local cjson = require "cjson"
                 ngx.req.read_body()
                 local body = ngx.req.get_body_data()
+                -- feature_flags must be a JSON array []; assert on the raw body since
+                -- decoding collapses [] and {} to the same empty Lua table (see issue #134)
+                if body:find('"feature_flags":%[%]') then
+                    print("EXTRACT METRICS JSON:feature_flags:array ")
+                end
                 json = cjson.decode(body)
                 print("EXTRACT METRICS JSON:" .. "type:" .. json["remediation_components"][1]["type"] .. " ")
                 print("EXTRACT METRICS JSON:" .. "name:" .. json["remediation_components"][1]["name"] .. " ")
@@ -157,6 +162,7 @@ GET /t
 --- grep_error_log eval
 qr/EXTRACT METRICS JSON:[^ ]*/
 --- grep_error_log_out
+EXTRACT METRICS JSON:feature_flags:array
 EXTRACT METRICS JSON:type:lua-bouncer
 EXTRACT METRICS JSON:name:nginx
 EXTRACT METRICS JSON:window_size:15


### PR DESCRIPTION
Fixes #134.

NPMPlus uses the cjson library from alpine, which does not provide `array_mt`. 

Since there's apparently no way to emit a `[]` from a LUA object with the default cjson, just replace it in the encoded string. 