### PR TITLE
fix appsec log spam

### DIFF
--- a/lib/crowdsec.lua
+++ b/lib/crowdsec.lua
@@ -745,7 +745,7 @@ function csmod.Allow(ip)
   -- that user configured the remediation component to always check on the appSec (even if there is a decision for the IP)
   if is_appsec_enabled() and (ok == true or is_always_send_to_appsec())  then
     local appsecOk, appsecRemediation, status_code, appsec_resp, err = csmod.AppSecCheck(ip)
-    if err ~= nil then
+    if err ~= nil and err ~= "" then
       ngx.log(ngx.ERR, "AppSec check: " .. err)
     end
     if appsecOk == false then


### PR DESCRIPTION
With dc1ecdeb7061b8d37c9b86313193b38aee378c70 err is sometimes "" instead of nil which results in log spam of allowed requests like this:

```
2026/07/20 16:02:57 [error] 1082#1082: *1289 [lua] crowdsec.lua:749: Allow(): AppSec check: , client: ..., server: _, request: "GET /api/ HTTP/1.1", host: "..."

2026/07/20 16:03:06 [error] 1082#1082: *1294 [lua] crowdsec.lua:749: Allow(): AppSec check: , client: ..., server: ..., request: "GET / HTTP/1.1", host: "..."

2026/07/20 16:03:11 [error] 1014#1014: *1304 [lua] crowdsec.lua:749: Allow(): AppSec check: , client: ..., server: ..., request: "GET /xrpc/com.atproto.sync.subscribeRepos HTTP/1.1", host: "..."
```