### PR TITLE
add remote_addr and timestamp variables to ban template

### DIFF
--- a/lib/plugins/crowdsec/ban.lua
+++ b/lib/plugins/crowdsec/ban.lua
@@ -1,4 +1,5 @@
 local utils = require "plugins.crowdsec.utils"
+local template = require "plugins.crowdsec.template"
 
 
 local M = {_TYPE='module', _NAME='ban.funcs', _VERSION='1.0-0'}
@@ -64,7 +65,13 @@ function M.apply(...)
         ngx.header.content_type = "text/html"
         ngx.header.cache_control = "no-cache"
         ngx.status = status
-        ngx.say(M.template_str)
+
+        local template_data = {}
+        template_data["remote_addr"] = ngx.var.remote_addr
+        template_data["timestamp"] = os.date("%Y-%m-%d %H:%M:%S %z", ngx.time())
+        local view = template.compile(M.template_str, template_data)
+
+        ngx.say(view)
         ngx.exit(status)
         return
     end

--- a/templates/ban.html
+++ b/templates/ban.html
@@ -17,6 +17,9 @@
             </svg>
             <h1 class="text-xl md:text-2xl lg:text-3xl xl:text-4xl"> CrowdSec Access Forbidden</h1>
             <p class="lg:text-xl md:text-lg"> You are unable to visit the website.</p>
+            <div class="ip-info text-sm">
+              Your IP <b><code>{{remote_addr}}</code></b> seems to be blocked, <a href="https://app.crowdsec.net/cti/{{remote_addr}}" id="ctiLink" target="_blank" style="text-decoration: underline;">check our CTI info</a> about it.
+            </div>
           </div>
           <div class="flex-col md:flex-row text-sm flex items-center">
             <p>


### PR DESCRIPTION
It would be really useful to have some variables available in the ban.html template.

This PR introduces the following two variables:
`remote_addr` - The visitors IP address as returned by nginx.var.remote_addr - `1.2.3.4`
`timestamp` - A timestamp in local time with timezone: `2026-07-30 14:21:10 +0200`

Other suggestions for variables which make the error message more useful are welcome.

In my case I use the information in the variables like so:
```HTML
<div class="ip-info text-sm">
Your IP <b><code>{{remote_addr}}</code></b> seems to have been blocked, <a href="https://app.crowdsec.net/cti/{{remote_addr}}" id="ctiLink" target="_blank" style="text-decoration: underline;">check our CTI info</a> about it or contact the <a href="mailto:servicedesk@example.com?subject=%5BLOGIN%5D%20CrowdSec%20Access%20Forbidden%20{{remote_addr}}&body=Dear%20Servicedesk%2C%0A%0AI%20am%20unable%20to%20visit%20login.example.com%20due%20to%20the%20following%20error%3A%0A%22CrowdSec%20Access%20Forbidden%22%0A%0AMy%20IP%20Address%20is%3A%20{{remote_addr}}%0ATimestamp%3A%20{{timestamp}}%0A%0AI%20have%20checked%20the%20information%20provided%20by%20CrowdSec%20here%3A%0Ahttps%3A%2F%2Fapp.crowdsec.net%2Fcti%2F{{remote_addr}}%0A%0AKind%20regards%0A" style="text-decoration: underline;">Servicedesk</a>.
</div>
```

Which looks like this:
<img width="888" height="756" alt="image" src="https://github.com/user-attachments/assets/56dd298c-67ac-4d16-b4a8-2fbec6bc0884" />
